### PR TITLE
Drop curl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "ext-curl": "*",
         "phpunit/phpunit": "^8.0|^7.0"
     },
     "autoload": {


### PR DESCRIPTION
**Pull Request description:**
Removes ext-curl from the require-dev list in composer.json. Curl is not used anymore for tests.

**Why should this Pull Request be merged:**
Less dependencies.

**Semantic Versioning Classification:**
- [ ] This PR includes major breaking changes (such as method changes)
- [ ] This PR includes **only** documentational changes (such as docblocks, README, etc.)
